### PR TITLE
Allowing jetty:run-war deployment

### DIFF
--- a/openwis-war/src/main/webapp/WEB-INF/config-openwis/openwis.properties
+++ b/openwis-war/src/main/webapp/WEB-INF/config-openwis/openwis.properties
@@ -1,0 +1,2 @@
+openwis.data_services_base_url       = http://HOSTNAME:8180
+openwis.management_services_base_url = http://HOSTNAME:8180


### PR DESCRIPTION
Thie openwis.properties file is "expected" to be copied by vagrant to the webapp deployment directory, This breaks any non-vagrant deployment so we provided a file with default values which fixes this. If the application is indeed deployed by vagrant, this file will be overwritten.